### PR TITLE
[GIT PULL] fix(modules/admin/warn.ts): Fix negative number of warns

### DIFF
--- a/modules/admin/warn.ts
+++ b/modules/admin/warn.ts
@@ -65,6 +65,10 @@ function add_user_warn(user_id: number, group_id: number, nr_warn: number)
                 /*
                  * First time get a warn.
                  */
+
+                if (nr_warn < 0)
+                        nr_warn = 0;
+
                 user_info = {warns_count: {[group_id]: 0}};
                 user_info.warns_count[group_id] = nr_warn;
                 fs.writeFileSync(user_file, JSON.stringify(user_info));


### PR DESCRIPTION
When a user is never warned, but get unwarned, the number of warns
shown on Telegram will be negative. This is because @nr_warn is -1
and it returns @nr_warn directly without any negative guard if the
user doesn't have a user_file.json.

Fix this by guarding the negative value, and replace it with 0.

Link: https://t.me/deeznutsisbig/1362
Discovered-by: Irvan Malik &lt;irvanmalik48@gmail.com&gt;
Signed-off-by: Alviro Iskandar Setiawan &lt;alviro.iskandar@gnuweeb.org&gt;