### PR TITLE
[GIT PULL] Reorder `/warn` request validation rules

### DIFF
--- a/modules/admin/warn.ts
+++ b/modules/admin/warn.ts
@@ -105,15 +105,6 @@ async function validate_request(ctx: any, bitmask: number) {
     return false;
   }
 
-  if (bitmask & U_MUST_REPLY && !message?.reply_to_message) {
-    await replyToMsgId(
-      ctx,
-      "You need to reply to a message to use this command.",
-      msg_id
-    );
-    return false;
-  }
-
   const admin_list = await ctx.getChatAdministrators();
 
   if (
@@ -121,6 +112,15 @@ async function validate_request(ctx: any, bitmask: number) {
     !admin_list.some((admin: any) => admin.user.id === ctx.from?.id)
   ) {
     await replyToMsgId(ctx, "You are not an admin!", msg_id);
+    return false;
+  }
+
+  if (bitmask & U_MUST_REPLY && !message?.reply_to_message) {
+    await replyToMsgId(
+      ctx,
+      "You need to reply to a message to use this command.",
+      msg_id
+    );
     return false;
   }
 


### PR DESCRIPTION
Make sure check `U_MUST_BE_AN_ADMIN` comes first before `U_MUST_REPLY`.
Prioritize admin privilege check over reply to message.

Fixes: ae82347d1afeff1cf287da957dec4857cb55b753 ("feat(modules/admin/warn.ts): Add warn admin module")
Signed-off-by: Alviro Iskandar Setiawan <alviro.iskandar@gnuweeb.org>