### PR TITLE
[GIT PULL] Command arguments spec for `/ban`, `/sban`, `/tban`, `/mute`, `/tmute`, `/kick` 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,18 +2,24 @@ import { bot } from "./config";
 import { commands } from "./modules/mod";
 import { dropWelcomeAndFarewell } from "./modules/admin/mod";
 import { createDefaults } from "./defaults";
+import { runTests } from "./tests"
 
-createDefaults();
+async function main()
+{
+        await runTests();
+        await createDefaults();
 
-commands.forEach((command) => {
-        bot.command(command.command!, command.function);
-});
+        commands.forEach((command) => {
+                bot.command(command.command!, command.function);
+        });
 
-bot.drop(dropWelcomeAndFarewell);
+        bot.drop(dropWelcomeAndFarewell);
 
-bot.launch();
+        bot.launch();
 
-console.log("[STARTED] Realm Guard is now online!");
+        console.log("[STARTED] Realm Guard is now online!");
+        process.once("SIGINT", () => bot.stop("SIGINT"));
+        process.once("SIGTERM", () => bot.stop("SIGTERM"));
+}
 
-process.once("SIGINT", () => bot.stop("SIGINT"));
-process.once("SIGTERM", () => bot.stop("SIGTERM"));
+main();

--- a/modules/admin/ban.ts
+++ b/modules/admin/ban.ts
@@ -6,61 +6,103 @@ import { writeFile, rm, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 
 /*
- * TODO(Viro_SSFS,ammarfaizi2):
- *
- *   Refactor this file again, it is confusing to follow.
- *   Sorry for the mess.
- *
+ * See argument variants spec: https://t.me/GNUWeeb/683627 (by Alviro).
  */
 
-const storage_dir = getStorageDir();
+const STORAGE_DIR = getStorageDir();
+const BAN_MODULE_RULES = [
+        "in_supergroup",
+        "user_is_admin",
+        "bot_is_admin",
+        "noreply_admin",
+] satisfies ValidateOptions[];
 
-async function do_ban(ctx: any, user: any, seconds: number = -1,
-                      revoke_msg: boolean = false, silent: boolean = false)
+const SIDE_NOTE = `<b>Side note:</b>
+Currently, the <code>[reason]</code> doesn't mean anything, but accepted.`;
+
+const BAN_ARG_SPEC = `
+<code>/ban</code> command arguments spec:
+
+  <code>/ban</code>   (must reply)
+  <code>/ban [reason]</code>   (must reply, *)
+  <code>/ban [user_id]</code>
+  <code>/ban [user_id] [reason]</code>
+
+  <code>/sban</code>   (must reply)
+  <code>/sban [reason]</code>   (must reply, *)
+  <code>/sban [user_id]</code>
+  <code>/sban [user_id] [reason]</code>
+
+*: The first word of the <code>[reason]</code> sentence must be NaN. If it is a number, it will fallback to <code>[user_id]</code> variants.
+
+${SIDE_NOTE}`;
+
+const TBAN_ARG_SPEC = `
+<code>/tban</code> command arguments spec:
+
+  <code>/tban [time]</code>   (must reply)
+  <code>/tban [time] [reason]</code>   (must reply, *)
+  <code>/tban [user_id] [time]</code>
+  <code>/tban [user_id] [time] [reason]</code>
+
+*: The first word of the <code>[reason]</code> sentence must be NaN. If it is a number, it will fallback to <code>[user_id] [time]</code> variants.
+
+${SIDE_NOTE}`;
+
+/**
+ * Perform banChatMember().
+ *
+ * @ctx       The chat context.
+ *
+ * @user      The user to be banned.
+ *
+ * @seconds   How long the user should be banned? (in seconds).
+ *            If @seconds is less than 30 secs, the @user will be
+ *            banned permanently.
+ *
+ * @silent    Send banned notice?
+ */
+async function do_ban(ctx: any, user: any, seconds: number = 0,
+                      silent: boolean = false)
 {
+        let silent_f = `${STORAGE_DIR}/ban_silent/`;
+
+        if (silent) {
+                if (!existsSync(silent_f))
+                        await mkdir(silent_f);
+
+                silent_f += `${ctx.chat.id}.temp`;
+                await writeFile(silent_f, "");
+        }
+
         let until_date;
 
-        if (seconds === -1) {
-                /*
-                 * Forever!
-                 */
+        if (seconds === 0) {
+                /* Forever. */
                 until_date = 0;
         } else {
                 until_date = Math.floor(Date.now() / 1000) + seconds;
         }
 
-        if (silent) {
-                // create a directory if it doesn't exist
-                if (!existsSync(`${storage_dir}ban_silent`))
-                        await mkdir(`${storage_dir}ban_silent`);
-                // create a file with 0 bytes in it
-                await writeFile(
-                        `${storage_dir}ban_silent/${ctx.chat.id}.temp`,
-                        "",
-                );
-        }
+        await ctx.banChatMember(user.id, until_date, {revoke_messages: true});
 
-        await ctx.telegram.banChatMember(ctx.chat.id, user.id, until_date, {
-                revoke_messages: revoke_msg,
-        });
-
-        const c = (until_date === 0) ? "" : "T";
-        const s = (silent) ? "S" : "";
-        console.log(`[${c}${s}BAN] ${user.first_name} (${user.id})`);
+        const T = (until_date) ? "T" : "";
+        const S = (silent) ? "S" : "";
+        console.log(`[${T}${S}BAN] ${user.first_name} (${user.id})`);
 
         if (silent) {
                 const time = setTimeout(async () => {
-                        await rm(`${storage_dir}ban_silent/${ctx.chat.id}.temp`);
+                        await rm(silent_f);
                         clearTimeout(time);
                 }, 4 * 1000);
                 return;
         }
 
-        let r;
-        if ("time_tban_arg" in ctx)
-                r = `User ${user.first_name} (${user.id}) is temporarily banned for ${ctx.time_tban_arg}!`;
+        let r = `User ${user.first_name} (${user.id}) `;
+        if (ctx?.tban_time_arg)
+                r += `is temporarily banned for ${ctx.tban_time_arg}!`;
         else
-                r = `User ${user.first_name} (${user.id}) has been banned!`;
+                r += `has been banned!`;
 
         await ctx.reply(r);
 }
@@ -76,36 +118,195 @@ async function do_unban(ctx: any, user: any, silent: boolean = false)
         await ctx.reply(`User ${user.first_name} (${user.id}) has been unbanned!`);
 }
 
-async function ban_with_reply(ctx: any, seconds: number = -1,
-                              revoke_msg: boolean = false,
-                              silent: boolean = false)
+function error_on_user_admin(user: any)
 {
-        await do_ban(ctx, ctx.message.reply_to_message.from, seconds,
-                     revoke_msg, silent);
+        const s = user?.status;
+        if (s === "creator" || s === "administrator")
+                return "You can't use this command against an admin!";
+
+        return null;
 }
 
-async function unban_with_reply(ctx: any)
+async function __parse_ban_cmd(ctx: any, args: string[])
 {
-        await do_unban(ctx, ctx.message.reply_to_message.from);
-}
+        let reason = "";
+        let user = null;
+        let err = null;
 
-async function ban_with_user_id(ctx: any, seconds: number = -1,
-                                revoke_msg: boolean = false,
-                                silent: boolean = false)
-{
-        const user = await extract_kick_query(ctx, ctx.message.text);
+        if (!args[1].match(/^\d+$/)) {
 
-        if (!user) {
-                if (!ctx.show_resolve_fail_msg)
-                        return false;
+                /*
+                 * This is a `/ban [reason]`. Must reply.
+                 *
+                 * [reason] is NaN, if it was a number, we would
+                 * fall to the 'try and catch' below here.
+                 */
+                reason = args.slice(1).join(" ");
+                user = ctx.message?.reply_to_message?.from;
+                if (!user)
+                        err = `You must reply to a message!`;
 
-                let x = ctx.message.text.split(" ");
-                await ctx.reply(`Cannot resolve user_id ${x[1]}`);
-                return false;
+                return [user, reason, err];
         }
 
-        await do_ban(ctx, user, seconds, revoke_msg, silent);
-        return true;
+
+        /*
+         * This is a `/ban [user_id] [reason]` where the
+         * `[reason]` is optional.
+         *
+         * Replied message is ignored.
+         */
+        try {
+                user = await ctx.getChatMember(Number(args[1]));
+                reason = args.slice(2).join(" ");
+                err = error_on_user_admin(user);
+
+                if (user?.user)
+                        user = user.user;
+
+        } catch (e) {
+                err = `Cannot resolve user_id ${args[1]}`;
+        }
+        return [user, reason, err];
+}
+
+/*
+ * This is used by `/ban` and `/sban`. They both have
+ * the same arguments spec.
+ */
+async function parse_ban_cmd(ctx: any)
+{
+        let args = ctx.message.text.split(" ");
+        let reason = "";
+        let err = null;
+        let user = null;
+
+        if (args.length > 1) {
+                [user, reason, err] = await __parse_ban_cmd(ctx, args);
+        } else {
+                /*
+                 * args.length === 1 (without arguments), must reply.
+                 */
+                user = ctx.message?.reply_to_message?.from;
+                if (!user)
+                        err = `You must reply to a message!`;
+        }
+
+        return {
+                user: user,
+                reason: reason,
+                err: err
+        };
+}
+
+/*
+ * Coupled with timeToSecond() parser in generic.ts.
+ */
+function is_time_pattern(s: string)
+{
+        return s.match(/^\d+(s|mo?|h|d|w|y)?$/);
+}
+
+async function __parse_tban_cmd(ctx: any, args: string[])
+{
+        let args1_is_tpat;
+        let args2_is_tpat;
+        let seconds = 0;
+        let reason = "";
+        let err = null;
+        let user = null;
+
+        /*
+         * Don't call is_time_pattern() too often.
+         */
+        args1_is_tpat = is_time_pattern(args[1]);
+
+        if (2 in args)
+                args2_is_tpat = is_time_pattern(args[2]);
+        else
+                args2_is_tpat = false;
+
+        if (!args1_is_tpat && !args2_is_tpat) {
+                err = "Invalid <code>[time]</code> pattern, accepted time pattern is:\n"+
+                      "<code>/^\\d+(s|mo?|h|d|w|y)?$/</code>";
+                return [null, null, null, err];
+        }
+
+        if (args1_is_tpat && !args2_is_tpat) {
+                /*
+                 * /tban [time]
+                 * /tban [time] [reason]
+                 *
+                 * Must reply. [reason] is optional, if provided,
+                 * the first word must be NaN.
+                 *
+                 * If the first word was a number, we would fall
+                 * to the `[user_id] [time]` variants below.
+                 */
+
+                user = ctx.message?.reply_to_message?.from;
+                if (!user) {
+                        err = "You must reply to a message!";
+                } else {
+                        seconds = timeToSecond(args[1]);
+                        reason = reason = args.slice(2).join(" ");
+                        ctx.tban_time_arg = args[1];
+                }
+
+                return [user, reason, seconds, err];
+        }
+
+        /*
+         * Handle these patterns:
+         *
+         * /tban [user_id] [time]
+         * /tban [user_id] [time] [reason]
+         *
+         * Replied message is ignored.
+         * args[2] must be a time pattern.
+         */
+        try {
+                user = await ctx.getChatMember(Number(args[1]));
+                err = error_on_user_admin(user);
+                reason = args.slice(3).join(" ");
+                seconds = timeToSecond(args[2]);
+                ctx.tban_time_arg = args[2];
+
+                if (user?.user)
+                        user = user.user;
+
+        } catch (e) {
+                err = `Cannot resolve user_id ${args[1]}`;
+        }
+
+        return [user, reason, seconds, err];
+}
+
+async function parse_tban_cmd(ctx: any)
+{
+        let args = ctx.message.text.split(" ");
+        let seconds = 0;
+        let reason = "";
+        let err = null;
+        let user = null;
+
+        if (args.length === 1) {
+                /*
+                 * Timed ban always needs arguments.
+                 */
+                err = `Invalid <code>${args[0]}</code> command arguments!`;
+        } else if (args.length >= 2) {
+                [user, reason, seconds, err] = await __parse_tban_cmd(ctx, args);
+        } else {
+                /* Impossible. */
+        }
+
+        return {
+                user: user,
+                reason: reason,
+                seconds: seconds,
+                err: err
+        };
 }
 
 async function unban_with_user_id(ctx: any)
@@ -119,73 +320,16 @@ async function unban_with_user_id(ctx: any)
         return true;
 }
 
-async function tban_with_reply(ctx: any, args: string[])
-{
-        ctx.time_tban_arg = args[1];
-        await ban_with_reply(ctx, timeToSecond(args[1]));
-        return true;
-}
-
-async function tban_with_user_id(ctx: any, args: string[])
-{
-        ctx.message.text = `/tban ${args[1]}`;
-        ctx.time_tban_arg = args[2];
-        ctx.show_resolve_fail_msg = true;
-        await ban_with_user_id(ctx, timeToSecond(args[2]));
-        return true;  
-}
-
-async function __ban_cmd(ctx: any, revoke_msg: boolean = false,
-                         silent: boolean = false)
-{
-        const rules = [
-                "in_supergroup",
-                "user_is_admin",
-                "bot_is_admin",
-                "noreply_admin",
-        ] satisfies ValidateOptions[];
-
-        if (!(await validateRequest(ctx, rules)))
-                return;
-
-        if (ctx.message?.text) {
-                if (await ban_with_user_id(ctx, -1, revoke_msg, silent))
-                        return;
-        }
-
-        if (ctx.message?.reply_to_message?.from) {
-                await ban_with_reply(ctx, -1, revoke_msg, silent);
-                return;
-        }
-
-        console.log("[ERROR] No valid reply or user ID!");
-        await ctx.reply("Please reply to a message or type the user ID to ban a user!");
-}
-
-async function ban_cmd(ctx: any)
-{
-        await __ban_cmd(ctx, false, false);
-}
-
 async function unban_cmd(ctx: any)
 {
-        const rules = [
-                "in_supergroup",
-                "user_is_admin",
-                "bot_is_admin",
-                "noreply_admin",
-        ] satisfies ValidateOptions[];
-
-        if (!(await validateRequest(ctx, rules)))
+        if (!(await validateRequest(ctx, BAN_MODULE_RULES)))
                 return;
 
-        if (ctx.message?.text) {
-                if (await unban_with_user_id(ctx))
-                        return;
-        }
+        if (await unban_with_user_id(ctx))
+                return;
 
         if (ctx.message?.reply_to_message?.from) {
-                await unban_with_reply(ctx);
+                await do_unban(ctx, ctx.message.reply_to_message.from);
                 return;
         }
 
@@ -193,75 +337,53 @@ async function unban_cmd(ctx: any)
         await ctx.reply("Please reply to a message or type the user ID to unban a user!");
 }
 
-async function send_invalid_tban_notice(ctx: any)
-{
-        const r =
-                `Invalid tban query!\n\n` +
-                `Usage:\n` +
-                `<code>/tban &lt;time&gt;</code>\n` +
-                `<code>/tban &lt;user_id&gt; &lt;time&gt;</code>`
-
-        await ctx.replyWithHTML(r);
-}
-
 async function tban_cmd(ctx: any)
 {
-        const rules = [
-                "in_supergroup",
-                "user_is_admin",
-                "bot_is_admin",
-                "noreply_admin",
-        ] satisfies ValidateOptions[];
-
-        if (!(await validateRequest(ctx, rules)))
+        if (!(await validateRequest(ctx, BAN_MODULE_RULES)))
                 return;
 
-        /*
-         * Expected values:
-         *
-         *   args[0] = /tban
-         *   args[1] = user_id
-         *   args[2] = time
-         *
-         * or
-         *
-         *   args[0] = /tban
-         *   args[1] = time
-         *
-         */
-        const args = ctx.message.text.split(" ");
-        switch (args.length) {
-        case 2:
-                /*
-                 * `/tban time` needs a replied message.
-                 */
-                if (!(await validateRequest(ctx, ["reply"])))
-                        return;
-
-                await tban_with_reply(ctx, args)
-                break;
-        case 3:
-                await tban_with_user_id(ctx, args);
-                break;
-        default:
-                await send_invalid_tban_notice(ctx);
-                break;
+        const ret = await parse_tban_cmd(ctx);
+        if (ret.err) {
+                await ctx.replyWithHTML(ret.err + `\n${TBAN_ARG_SPEC}`);
+                return;
         }
+
+        /*
+         * TODO(???): What should we do with @ret.reason?
+         */
+        await do_ban(ctx, ret.user, ret.seconds, false);
+}
+
+async function __ban_cmd(ctx: any, silent: boolean)
+{
+        if (!(await validateRequest(ctx, BAN_MODULE_RULES)))
+                return;
+
+        const ret = await parse_ban_cmd(ctx);
+        if (ret.err) {
+                await ctx.replyWithHTML(ret.err + `\n${BAN_ARG_SPEC}`);
+                return;
+        }
+
+        /*
+         * TODO(???): What should we do with @ret.reason?
+         */
+        await do_ban(ctx, ret.user, 0, silent);
+}
+
+async function ban_cmd(ctx: any)
+{
+        await __ban_cmd(ctx, false);
 }
 
 async function sban_cmd(ctx: any)
 {
         /*
          * Pretty much the same thing as `/ban` but:
-         * `silent: true`.
+         * silent === true
          */
-        await __ban_cmd(ctx, false, true);
+        await __ban_cmd(ctx, true);
 }
-
-export const banCommand: Command = {
-        command: "ban",
-        function: ban_cmd
-};
 
 export const unbanCommand: Command = {
         command: "unban",
@@ -272,6 +394,11 @@ export const unbanCommand: Command = {
 export const tbanCommand: Command = {
         command: "tban",
         function: tban_cmd
+};
+
+export const banCommand: Command = {
+        command: "ban",
+        function: ban_cmd
 };
 
 // `/sban` command (silently ban user)

--- a/modules/admin/ban.ts
+++ b/modules/admin/ban.ts
@@ -99,8 +99,8 @@ async function do_ban(ctx: any, user: any, seconds: number = 0,
         }
 
         let r = `User ${user.first_name} (${user.id}) `;
-        if (ctx?.tban_time_arg)
-                r += `is temporarily banned for ${ctx.tban_time_arg}!`;
+        if (ctx?.time_arg)
+                r += `is temporarily banned for ${ctx.time_arg}!`;
         else
                 r += `has been banned!`;
 
@@ -172,9 +172,9 @@ async function __parse_ban_cmd(ctx: any, args: string[])
 
 /*
  * This is used by `/ban` and `/sban`. They both have
- * the same arguments spec.
+ * the same arguments spec. Export this for mute.ts.
  */
-async function parse_ban_cmd(ctx: any)
+export async function parse_ban_cmd(ctx: any)
 {
         let args = ctx.message.text.split(" ");
         let reason = "";
@@ -250,7 +250,7 @@ async function __parse_tban_cmd(ctx: any, args: string[])
                 } else {
                         seconds = timeToSecond(args[1]);
                         reason = reason = args.slice(2).join(" ");
-                        ctx.tban_time_arg = args[1];
+                        ctx.time_arg = args[1];
                 }
 
                 return [user, reason, seconds, err];
@@ -270,7 +270,7 @@ async function __parse_tban_cmd(ctx: any, args: string[])
                 err = error_on_user_admin(user);
                 reason = args.slice(3).join(" ");
                 seconds = timeToSecond(args[2]);
-                ctx.tban_time_arg = args[2];
+                ctx.time_arg = args[2];
 
                 if (user?.user)
                         user = user.user;
@@ -282,7 +282,10 @@ async function __parse_tban_cmd(ctx: any, args: string[])
         return [user, reason, seconds, err];
 }
 
-async function parse_tban_cmd(ctx: any)
+/*
+ * Export this for mute.ts
+ */
+export async function parse_tban_cmd(ctx: any)
 {
         let args = ctx.message.text.split(" ");
         let seconds = 0;

--- a/tests.ts
+++ b/tests.ts
@@ -1,0 +1,4 @@
+
+export async function runTests()
+{
+}

--- a/tests.ts
+++ b/tests.ts
@@ -1,4 +1,7 @@
 
+import { TestBanModuleParsers } from "./modules/admin/ban";
+
 export async function runTests()
 {
+        await TestBanModuleParsers();
 }


### PR DESCRIPTION
Hi Irvan,

This set contains the recent command arguments spec that Alviro
proposed at: https://t.me/GNUWeeb/683627

   - Implement `/ban`, `/sban`, `/tban` command arguments spec (me).

   - Add unit test for the `/ban` command parser functions (me).

   - Implement `/mute`, `/tmute` command arguments spec (me).

   - Implement `/kick` command arguments spec (me).

Mute and kick modules reuse the parser functions from ban module.

Please pull!

```
The following changes since commit 9d3529a7b0cf2d5a82673c07dcafe666ea5fe98b:

  Merge pull request #15 from GNUWeeb/dev/irvanmalik48 (2022-12-28 08:14:41 +0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/realm-guard.git dev.command_arguments

for you to fetch changes up to 0c0f5d4cd031afb1b2f1644ca9b6bcd314628595:

  feat(modules/admin/kick.ts): Implement `/kick` command arg spec (2022-12-29 09:05:06 +0700)

----------------------------------------------------------------
Ammar Faizi (5):
      feat(modules/admin/ban.ts): Implement `/ban` command arg spec
      feat(tests.ts): Implement unit tests at initialization
      feat(tests.js): Add ban command parser unit tests
      feat(modules/admin/mute.ts): Implement `/mute` command arg spec
      feat(modules/admin/kick.ts): Implement `/kick` command arg spec

 index.ts              |  24 +-
 modules/admin/ban.ts  | 683 ++++++++++++++++++++++++++++++----------
 modules/admin/kick.ts |  54 ++--
 modules/admin/mute.ts | 189 +++++------
 tests.ts              |   7 +
 5 files changed, 649 insertions(+), 308 deletions(-)
 create mode 100644 tests.ts
```